### PR TITLE
adapt docker-compose file to latest changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,40 @@
-version: '3'
+version: "3"
 services:
   deployment-service:
-    image: ghcr.io/eclipse-researchlabs/smartclide-deployment-service:develop
+    image: ghcr.io/eclipse-researchlabs/smartclide/smartclide-deployment-service:2022-07-15
     container_name: deployment-service
     hostname: deployment-service
     ports:
-      - 3000:3000   
+      - 3000:3000
     environment:
       - GITLAB_URL=https://gitlab.dev.smartclide.eu/
       - MOM_HOST=rabbitmq
-      - MOM_PORT=3332
+      - MOM_PORT=5672
       - MOM_USER=
       - MOM_PASSWORD=
       - MONGO_HOST=mongo
       - MONGO_PORT=27017
+      - MONGO_DATABASE=
       - MONGO_USER=
       - MONGO_PASSWORD=
-    links:
-      - rabbitmq:rabbitmq
-      - mongo:mongo
+    networks:
+      - deployment-service
 
   rabbitmq:
-    image: "rabbitmq:latest"
+    image: "rabbitmq:3.9.11-management"
+    ports:
+      - 5672:5672
+    networks:
+      - deployment-service
 
   mongo:
-    image: "mongo:4.4.14"
+    image: "mongo:5.0.8-focal"
     volumes:
       - ./data:/data/db
     ports:
       - 27017:27017
+    networks:
+      - deployment-service
 
-volumes:
-  database-data: 
+networks:
+  deployment-service:


### PR DESCRIPTION
fix image name
fix MOM_PORT
add MONGO_DATABASE env var
use network instead of deprecated links
update rabbitmq and mongo images to versions used in smartclide
remove obsolete volumes definition